### PR TITLE
Modify name so that it's different from videojs-swf

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "videojs-swf",
+  "name": "videojs-flashls-swf",
   "description": "The Flash-fallback video player for video.js (http://videojs.com)",
   "version": "5.4.0",
   "copyright": "Copyright 2014 Brightcove, Inc. https://github.com/videojs/video-js-swf/blob/master/LICENSE",


### PR DESCRIPTION
This name will be used in deployments as well, and if we end up publishing this to NPM at some point this gives us a route to having a distinct name in case we have two separate forks instead of merging back in.