### PR TITLE
Sum and Expose COGs metrics

### DIFF
--- a/src/VideoJS.as
+++ b/src/VideoJS.as
@@ -348,6 +348,9 @@ package{
                 case "audioTrack":
                     return _app.model.audioTrack;
                     break;
+                case "stats":
+                    return _app.model.stats;
+                    break;
             }
             return null;
         }

--- a/src/com/videojs/VideoJSModel.as
+++ b/src/com/videojs/VideoJSModel.as
@@ -161,6 +161,13 @@ package com.videojs{
             return {};
         }
 
+        public function get stats(): Object{
+            if(_provider) {
+                return _provider.stats;
+            }
+            return {};
+        }
+
         public function get volume():Number{
             return _volume;
         }

--- a/src/com/videojs/providers/HLSProvider.as
+++ b/src/com/videojs/providers/HLSProvider.as
@@ -268,10 +268,22 @@ package com.videojs.providers{
           var fragmentTransferTime = metrics.parsing_end_time - metrics.loading_request_time;
 
           _mediaRequests++;
-          _mediaSecondsLoaded = _mediaSecondsLoaded + metrics.duration / 1000;
-          _mediaBytesTransferred = _mediaBytesTransferred + metrics.size;
-          _mediaTransferDuration = _mediaTransferDuration + fragmentTransferTime;
-          _currentBandwidth = metrics.bandwidth;
+
+          if (!isNaN(metrics.duration)) {
+            _mediaSecondsLoaded = _mediaSecondsLoaded + metrics.duration / 1000;
+          }
+
+          if (!isNaN(metrics.size)) {
+            _mediaBytesTransferred = _mediaBytesTransferred + metrics.size;
+          }
+
+          if (!isNaN(fragmentTransferTime)) {
+            _mediaTransferDuration = _mediaTransferDuration + fragmentTransferTime;
+          }
+
+          if (!isNaN(metrics.bandwidth)) {
+            _currentBandwidth = metrics.bandwidth;
+          }
         }
 
         private function _onFragmentAborted(event:HLSEvent):void

--- a/src/com/videojs/providers/HLSProvider.as
+++ b/src/com/videojs/providers/HLSProvider.as
@@ -265,7 +265,6 @@ package com.videojs.providers{
         private function _onFragmentLoaded(event:HLSEvent):void
         {
           var metrics = event.loadMetrics;
-          var fragmentTransferTime = metrics.parsing_end_time - metrics.loading_request_time;
 
           _mediaRequests++;
 
@@ -277,8 +276,8 @@ package com.videojs.providers{
             _mediaBytesTransferred = _mediaBytesTransferred + metrics.size;
           }
 
-          if (!isNaN(fragmentTransferTime)) {
-            _mediaTransferDuration = _mediaTransferDuration + fragmentTransferTime;
+          if (!isNaN(metrics.processing_duration)) {
+            _mediaTransferDuration = _mediaTransferDuration + metrics.processing_duration;
           }
 
           if (!isNaN(metrics.bandwidth)) {

--- a/src/com/videojs/providers/HLSProvider.as
+++ b/src/com/videojs/providers/HLSProvider.as
@@ -252,27 +252,33 @@ package com.videojs.providers{
           }
         }
 
+        /**
+         * This is called whenever a segment is successfully loaded.
+         *
+         * Whenever a segment is loaded we keep metrics on a series of statistics, such as
+         * - how many segments have been requested
+         * - how many seconds of media have been downloaded
+         * - how many bytes have been transferred
+         * - how much times has been spent downloading segments
+         * - what the bandwidth was for the latest downloaded segment
+         */
         private function _onFragmentLoaded(event:HLSEvent):void
         {
           var metrics = event.loadMetrics;
           var fragmentTransferTime = metrics.parsing_end_time - metrics.loading_request_time;
+
           _mediaRequests++;
           _mediaSecondsLoaded = _mediaSecondsLoaded + metrics.duration / 1000;
           _mediaBytesTransferred = _mediaBytesTransferred + metrics.size;
           _mediaTransferDuration = _mediaTransferDuration + fragmentTransferTime;
           _currentBandwidth = metrics.bandwidth;
-          Log.info("media request count" + _mediaRequests);
-          Log.info("media seconds loaded " + _mediaSecondsLoaded);
-          Log.info("media bytes loaded " + _mediaBytesTransferred);
-          Log.info("media bandwidth " + _currentBandwidth);
-
         }
 
         private function _onFragmentAborted(event:HLSEvent):void
         {
           _mediaRequestsAborted++;
-          Log.info("media request count" + _mediaRequestsAborted);
         }
+
         public function get loop():Boolean{
             return _loop;
         }
@@ -754,11 +760,11 @@ package com.videojs.providers{
 
         public function get videoPlaybackQuality():Object{
             if (_hls.stream != null &&
-                _hls.stream.hasOwnProperty('decodedFrames') &&
-                _hls.stream.info.hasOwnProperty('droppedFrames')) {
+                _hls.stream.hasOwnProperty('totalFrames') &&
+                _hls.stream.hasOwnProperty('droppedFrames')) {
                 return {
-                    droppedVideoFrames: _hls.stream.info.droppedFrames,
-                    totalVideoFrames: _hls.stream.decodedFrames + _hls.stream.info.droppedFrames
+                    droppedVideoFrames: _hls.stream.droppedFrames,
+                    totalVideoFrames: _hls.stream.totalFrames
                 };
             }
             return {};

--- a/src/com/videojs/providers/HTTPAudioProvider.as
+++ b/src/com/videojs/providers/HTTPAudioProvider.as
@@ -455,6 +455,11 @@ package com.videojs.providers{
             return;
         }
 
+        // not supported in this provider
+        public function get stats():Object {
+            return {};
+        }
+
         private function doLoadCalculations():void{
             // if the load is finished
             if(_sound.bytesLoaded == _sound.bytesTotal){

--- a/src/com/videojs/providers/HTTPVideoProvider.as
+++ b/src/com/videojs/providers/HTTPVideoProvider.as
@@ -529,6 +529,11 @@ package com.videojs.providers{
             return;
         }
 
+        // not supported in this provider
+        public function get stats():Object {
+            return {};
+        }
+
         private function initNetConnection():void{
             // The video element triggers loadstart as soon as the resource selection algorithm selects a source
             // this is somewhat later than that moment but relatively close

--- a/src/com/videojs/providers/IProvider.as
+++ b/src/com/videojs/providers/IProvider.as
@@ -266,5 +266,7 @@ package com.videojs.providers{
           * Should return the list of alt-audio-tracks that this content has.
           */
         function get altAudioTracks():Array;
+
+        function get stats():Object;
     }
 }

--- a/src/com/videojs/providers/IProvider.as
+++ b/src/com/videojs/providers/IProvider.as
@@ -267,6 +267,9 @@ package com.videojs.providers{
           */
         function get altAudioTracks():Array;
 
+        /**
+         * Should return metrics that calculate COGS (cost of goods and services).
+         */
         function get stats():Object;
     }
 }

--- a/src/com/videojs/providers/RTMPVideoProvider.as
+++ b/src/com/videojs/providers/RTMPVideoProvider.as
@@ -479,6 +479,11 @@ package com.videojs.providers{
             return;
         }
 
+        // not supported in this provider
+        public function get stats():Object {
+            return {};
+        }
+
         private function initNetConnection():void{
             if(_nc == null){
                 _nc = new NetConnection();


### PR DESCRIPTION
This pull request sums metrics to calculate cost of goods an services (COGS).  They are exposed via vjs_getProperty("stats").  The exposed statistics are:

- Current bandwidth (as of the most recently downloaded segment)
- Number of media requests
- Number of media requests errored
- Number of media requests aborted
- Number of bytes downloaded
- Duration of segments downloaded
- Time spent downloading segments

There will be an accompanying pull request to expose these statistics in the flashls source handler as well.