### PR TITLE
Call play after manifest loaded if play was called before manifest was loaded

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@brightcove/flashls": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@brightcove/flashls/-/flashls-1.2.0.tgz",
-      "integrity": "sha512-eZhoHDjnPVBy+ivJJaSjDGUMjm2G1LJcFdfCBxbHXiVezXxYWC2Jlarvy8Ivr2NZO/WY8T4J8TJmWsWtlschWw=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@brightcove/flashls/-/flashls-1.2.1.tgz",
+      "integrity": "sha512-Etqw9PDVfM/rnlONR50ZCiJFBensWph7NxZ9Gb8mvpM29IyUXYMbQnmNSdhqoCT4aqgqz2iksLQ6rvMRJJ5ikg=="
     },
     "abbrev": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
     "version": "chg release -y && grunt dist && git add -f dist/ && git add CHANGELOG.md"
   },
   "dependencies": {
-    "@brightcove/flashls": "1.2.0"
+    "@brightcove/flashls": "1.2.1"
   }
 }

--- a/src/com/videojs/providers/HLSProvider.as
+++ b/src/com/videojs/providers/HLSProvider.as
@@ -46,6 +46,7 @@ package com.videojs.providers{
         private var _duration:Number = 0;
         private var _isAutoPlay:Boolean = false;
         private var _isManifestLoaded:Boolean = false;
+        private var _waitingOnManifest:Boolean = false;
         private var _isPlaying:Boolean = false;
         private var _isSeeking:Boolean = false;
         private var _isPaused:Boolean = true;
@@ -133,8 +134,9 @@ package com.videojs.providers{
           _duration = event.levels[0].duration;
           _metadata.width = event.levels[0].width;
           _metadata.height = event.levels[0].height;
-          if(_isAutoPlay || _looping) {
+          if(_isAutoPlay || _looping || _waitingOnManifest) {
             _looping = false;
+            _waitingOnManifest = false;
             play();
           }
           _model.broadcastEventExternally(ExternalEventName.ON_LOAD_START);
@@ -611,6 +613,8 @@ package com.videojs.providers{
               default:
                 break;
             }
+          } else {
+            _waitingOnManifest = true;
           }
         }
 


### PR DESCRIPTION
If `play()` is called before Flashls has loaded the manifest, the player never actually plays because it waits for the manifest to be loaded. However, there is no mechanism to call play after the manifest has been loaded in this scenario, requiring an extra click from the user to get playback started. This change will re-call play if it was called before manifest loaded.